### PR TITLE
下调 update_interval

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -133,7 +133,7 @@ impl RangeReaderBuilder {
             uc_urls: vec![],
             io_tries: 10,
             uc_tries: 10,
-            update_interval: Duration::from_secs(5 * 60),
+            update_interval: Duration::from_secs(60),
             punish_duration: Duration::from_secs(30),
             base_timeout: Duration::from_millis(500),
             max_punished_times: 5,

--- a/src/host_selector.rs
+++ b/src/host_selector.rs
@@ -220,7 +220,7 @@ impl HostSelectorBuilder {
             hosts,
             update_func: None,
             should_punish_func: None,
-            update_interval: Duration::from_secs(5 * 60),
+            update_interval: Duration::from_secs(60),
             punish_duration: Duration::from_secs(30),
             base_timeout: Duration::from_millis(500),
             max_punished_times: 5,


### PR DESCRIPTION
原来的值太高，但因为 uc v4 query 用 consul 做后端时 ttl 只有三分钟，update_interval 如果大幅高于这个值的话，就没有实际意义。