### PR TITLE
v2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-download"
-version = "2.0.0"
+version = "2.0.1"
 description = "Qiniu Resource (Cloud) Download SDK for Rust."
 authors = ["Bachue Zhou <zhourong@qiniu.com>", "longbai <baishunlong@qiniu.com>", "qiniusdk <sdk@qiniu.com>"]
 documentation = "https://docs.rs/qiniu-download"

--- a/src/async_api/download.rs
+++ b/src/async_api/download.rs
@@ -264,43 +264,6 @@ struct AsyncRangeReaderInner {
 }
 
 impl AsyncRangeReader {
-    // pub(super) fn from_env_with_extra_items(
-    //     key: String,
-    // ) -> Option<(Self, String, Option<usize>, Option<usize>)> {
-    //     with_current_qiniu_config(|config| {
-    //         config.and_then(|config| {
-    //             config.with_key(&key.to_owned(), |config| {
-    //                 let config = Arc::new(config.to_owned());
-    //                 let range_reader_config = config.to_owned();
-    //                 (
-    //                     config.max_retry_concurrency(),
-    //                     config.retry(),
-    //                     Box::pin(async move {
-    //                         config
-    //                             .get_or_init_async_range_reader_inner(move || async move {
-    //                                 AsyncRangeReaderBuilder::from_config(
-    //                                     String::new(),
-    //                                     &range_reader_config,
-    //                                 )
-    //                                 .build_inner()
-    //                                 .await
-    //                             })
-    //                             .await
-    //                     }),
-    //                 )
-    //             })
-    //         })
-    //     })
-    //     .map(|(max_retry_concurrency, total_tries, fut)| {
-    //         (
-    //             Self(Arc::new(AsyncLazy::new(fut))),
-    //             key,
-    //             max_retry_concurrency,
-    //             total_tries,
-    //         )
-    //     })
-    // }
-
     pub(super) async fn update_urls(&self) -> bool {
         self.inner().await.io_selector.update_hosts().await
     }
@@ -342,7 +305,7 @@ impl AsyncRangeReader {
         pos: u64,
         size: u64,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         on_host_selected: F,
@@ -422,7 +385,7 @@ impl AsyncRangeReader {
         &self,
         ranges: &[(u64, u64)],
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         on_host_selected: F,
@@ -554,7 +517,7 @@ impl AsyncRangeReader {
     pub(super) async fn exist<F: FnMut(HostInfo) -> Fut, Fut: Future<Output = ()>>(
         &self,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         on_host_selected: F,
@@ -614,7 +577,7 @@ impl AsyncRangeReader {
     pub(super) async fn file_size<F: FnMut(HostInfo) -> Fut, Fut: Future<Output = ()>>(
         &self,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         on_host_selected: F,
@@ -676,7 +639,7 @@ impl AsyncRangeReader {
     pub(super) async fn download<F: FnMut(HostInfo) -> Fut, Fut: Future<Output = ()>>(
         &self,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         mut on_host_selected: F,
@@ -716,7 +679,7 @@ impl AsyncRangeReader {
     async fn _download<F: FnMut(HostInfo) -> Fut, Fut: Future<Output = ()>>(
         &self,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         init_from: u64,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
@@ -818,7 +781,7 @@ impl AsyncRangeReader {
         &self,
         size: u64,
         key: &str,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         on_host_selected: F,
@@ -897,7 +860,7 @@ impl AsyncRangeReader {
         key: &str,
         method: Method,
         api_name: ApiName,
-        async_task_id: usize,
+        async_task_id: u32,
         tries_info: TriesInfo<'_>,
         trying_hosts: &TryingHosts,
         mut on_host_selected: F2,

--- a/src/async_api/download.rs
+++ b/src/async_api/download.rs
@@ -3,7 +3,7 @@
 use super::{
     super::{
         base::{credential::Credential, download::RangeReaderBuilder as BaseRangeReaderBuilder},
-        config::{build_async_range_reader_builder_from_config, Config, Timeouts},
+        config::{build_range_reader_builder_from_config, Config, Timeouts},
     },
     dot::{ApiName, DotType, Dotter},
     host_selector::{HostInfo, HostSelector, HostSelectorBuilder},
@@ -87,7 +87,7 @@ pub fn sign_download_url_with_lifetime(
 }
 
 #[derive(Debug)]
-pub(crate) struct AsyncRangeReaderBuilder(BaseRangeReaderBuilder);
+pub(super) struct AsyncRangeReaderBuilder(BaseRangeReaderBuilder);
 
 impl From<BaseRangeReaderBuilder> for AsyncRangeReaderBuilder {
     fn from(builder: BaseRangeReaderBuilder) -> Self {
@@ -102,11 +102,11 @@ impl From<AsyncRangeReaderBuilder> for BaseRangeReaderBuilder {
 }
 
 impl AsyncRangeReaderBuilder {
-    pub(crate) fn take_key(&mut self) -> String {
+    pub(super) fn take_key(&mut self) -> String {
         take(&mut self.0.key)
     }
 
-    pub(crate) fn build(self) -> AsyncRangeReader {
+    pub(super) fn build(self) -> AsyncRangeReader {
         AsyncRangeReader(Arc::new(AsyncLazy::new(Box::pin(async move {
             self.build_inner().await
         }))))
@@ -243,12 +243,12 @@ impl AsyncRangeReaderBuilder {
     }
 
     pub(crate) fn from_config(key: String, config: &Config) -> Self {
-        build_async_range_reader_builder_from_config(key, config)
+        build_range_reader_builder_from_config(key, config).into()
     }
 }
 
 #[derive(Clone)]
-pub(crate) struct AsyncRangeReader(Arc<AsyncLazy<Arc<AsyncRangeReaderInner>>>);
+pub(super) struct AsyncRangeReader(Arc<AsyncLazy<Arc<AsyncRangeReaderInner>>>);
 
 #[derive(Debug)]
 struct AsyncRangeReaderInner {

--- a/src/async_api/host_selector.rs
+++ b/src/async_api/host_selector.rs
@@ -621,22 +621,22 @@ pub(super) enum PunishResult {
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct HostInfo {
+pub(super) struct HostInfo {
     host: String,
     timeout_power: usize,
     timeout: Duration,
 }
 
 impl HostInfo {
-    pub(crate) fn host(&self) -> &str {
+    pub(super) fn host(&self) -> &str {
         &self.host
     }
 
-    pub(crate) fn timeout_power(&self) -> usize {
+    pub(super) fn timeout_power(&self) -> usize {
         self.timeout_power
     }
 
-    pub(crate) fn timeout(&self) -> Duration {
+    pub(super) fn timeout(&self) -> Duration {
         self.timeout
     }
 }

--- a/src/async_api/host_selector.rs
+++ b/src/async_api/host_selector.rs
@@ -272,9 +272,11 @@ impl HostPunisher {
         hosts_count * usize::from(self.max_punished_hosts_percent) / 100
     }
 
-    fn is_available(&self, punished_info: &PunishedInfo) -> bool {
-        !punished_info.failed_to_connect
-            && punished_info.continuous_punished_times <= self.max_punished_times
+    fn is_available(&self, punished_info: &PunishedInfo, connection_sensitive: bool) -> bool {
+        if connection_sensitive && punished_info.failed_to_connect {
+            return false;
+        }
+        punished_info.continuous_punished_times <= self.max_punished_times
     }
 
     fn is_punishment_expired(&self, punished_info: &PunishedInfo) -> bool {
@@ -434,7 +436,7 @@ impl HostSelector {
                     .get(host)
                     .map(|punished_info| {
                         self.host_punisher.is_punishment_expired(&punished_info)
-                            || self.host_punisher.is_available(&punished_info)
+                            || self.host_punisher.is_available(&punished_info, true)
                     })
                     .unwrap_or(true)
             })
@@ -585,7 +587,7 @@ impl HostSelector {
                     host, punished_info.continuous_punished_times, punished_info.timeout_power
                 );
 
-                if !self.host_punisher.is_available(&punished_info) {
+                if !self.host_punisher.is_available(&punished_info, false) {
                     return PunishResult::PunishedAndFreezed;
                 }
             }
@@ -609,7 +611,7 @@ impl HostSelector {
     }
 
     fn is_satisfied_with(&self, punished_info: &PunishedInfo) -> bool {
-        self.host_punisher.is_available(punished_info)
+        self.host_punisher.is_available(punished_info, true)
             && self.hosts_updater.current_timeout_power.load(Relaxed) >= punished_info.timeout_power
     }
 }

--- a/src/async_api/mod.rs
+++ b/src/async_api/mod.rs
@@ -13,7 +13,6 @@ pub use dot::{
 };
 
 mod download;
-pub(crate) use download::AsyncRangeReaderBuilder;
 pub use download::{sign_download_url_with_deadline, sign_download_url_with_lifetime, RangePart};
 
 mod retrier;

--- a/src/async_api/req_id.rs
+++ b/src/async_api/req_id.rs
@@ -27,13 +27,13 @@ pub fn total_download_duration(t: SystemTime) -> Duration {
 
 pub(crate) const REQUEST_ID_HEADER: &str = "X-ReqId";
 
-pub(crate) fn get_req_id(tn: SystemTime, index: usize, timeout: Duration) -> HeaderValue {
+pub(crate) fn get_req_id(tn: SystemTime, tries: usize, timeout: Duration) -> HeaderValue {
     let (start_time, delta) = get_start_time_and_delta(tn);
     HeaderValue::try_from(format!(
         "r{}-{}-t{}-o{}",
         start_time,
         delta,
-        index,
+        tries,
         timeout.as_millis()
     ))
     .expect("Unexpected invalid header value")
@@ -41,8 +41,8 @@ pub(crate) fn get_req_id(tn: SystemTime, index: usize, timeout: Duration) -> Hea
 
 pub(crate) fn get_req_id2(
     tn: SystemTime,
-    index: usize,
-    index2: usize,
+    tries: usize,
+    async_task_id: u32,
     timeout: Duration,
 ) -> HeaderValue {
     let (start_time, delta) = get_start_time_and_delta(tn);
@@ -50,8 +50,8 @@ pub(crate) fn get_req_id2(
         "r{}-{}-t{}-a{}-o{}",
         start_time,
         delta,
-        index,
-        index2,
+        tries,
+        async_task_id,
         timeout.as_millis()
     ))
     .expect("Unexpected invalid header value")

--- a/src/async_api/retrier.rs
+++ b/src/async_api/retrier.rs
@@ -1,4 +1,5 @@
 use super::{
+    dot::{ApiName, DotType},
     download::{AsyncRangeReader, IoResult3, Result3, TriesInfo, TryingHosts},
     host_selector::HostInfo,
     RangePart,
@@ -49,23 +50,19 @@ impl AsyncRangeReaderWithRangeReader {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderReadAtRetrier::new(
-                    pos,
-                    size,
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderReadAt, |async_task_id| {
+            RangeReaderReadAtRetrier::new(
+                pos,
+                size,
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
     }
 
     pub(super) async fn read_multi_ranges(
@@ -76,107 +73,243 @@ impl AsyncRangeReaderWithRangeReader {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderReadMultiRangesRetrier::new(
-                    ranges,
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderReadMultiRanges, |async_task_id| {
+            RangeReaderReadMultiRangesRetrier::new(
+                ranges,
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
     }
 
     pub(super) async fn exist(&self, key: &str) -> IoResult<bool> {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderExistRetrier::new(
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderExist, |async_task_id| {
+            RangeReaderExistRetrier::new(
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
     }
 
     pub(super) async fn file_size(&self, key: &str) -> IoResult<u64> {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderFileSizeRetrier::new(
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderFileSize, |async_task_id| {
+            RangeReaderFileSizeRetrier::new(
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
     }
 
     pub(super) async fn download(&self, key: &str) -> IoResult<Vec<u8>> {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderDownloadRetrier::new(
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderDownloadTo, |async_task_id| {
+            RangeReaderDownloadRetrier::new(
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
     }
 
     pub(super) async fn read_last_bytes(&self, key: &str, size: u64) -> IoResult<(Vec<u8>, u64)> {
         let have_tried: AtomicUsize = Default::default();
         let trying_hosts: TryingHosts = Default::default();
         let selected_info: SelectedHostInfo = Default::default();
-        try_with_timeout(
-            |async_task_id| {
-                RangeReaderReadLastBytesRetrier::new(
-                    size,
-                    key,
-                    async_task_id,
-                    &self.inner,
-                    TriesInfo::new(&have_tried, self.total_tries),
-                    &trying_hosts,
-                    &selected_info,
-                )
-            },
-            self.max_retry_concurrency,
-        )
+        self.try_with_timeout(ApiName::RangeReaderReadLastBytes, |async_task_id| {
+            RangeReaderReadLastBytesRetrier::new(
+                size,
+                key,
+                async_task_id,
+                &self.inner,
+                TriesInfo::new(&have_tried, self.total_tries),
+                &trying_hosts,
+                &selected_info,
+            )
+        })
         .await
-        .into()
+    }
+
+    async fn try_with_timeout<
+        Output,
+        T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
+        F: Fn(u32) -> T,
+    >(
+        &self,
+        api_name: ApiName,
+        f: F,
+    ) -> IoResult<Output> {
+        let begin_at = Instant::now();
+        let result = _try_with_timeout(f, self.max_retry_concurrency).await;
+        self.inner
+            .dot(
+                DotType::Sdk,
+                api_name,
+                matches!(result, TryResult::Success(_)),
+                begin_at.elapsed(),
+            )
+            .await
+            .ok();
+        return result.into();
+
+        async fn _try_with_timeout<
+            Output,
+            T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
+            F: Fn(u32) -> T,
+        >(
+            f: F,
+            max: u32,
+        ) -> TryResult<Output> {
+            struct FutWithIdx<
+                Output,
+                T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
+            > {
+                idx: usize,
+                fut: T,
+            }
+
+            impl<
+                    Output,
+                    T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
+                > Future for FutWithIdx<Output, T>
+            {
+                type Output = IoResult3<Output>;
+
+                fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                    Pin::new(&mut self.fut).poll(cx)
+                }
+            }
+
+            #[async_trait]
+            impl<
+                    Output,
+                    T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
+                > MaybeTimeout for FutWithIdx<Output, T>
+            {
+                async fn base_timeout(&self) -> Duration {
+                    self.fut.base_timeout().await
+                }
+
+                async fn increase_timeout_power_if_timed_out(self) {
+                    self.fut.increase_timeout_power_if_timed_out().await
+                }
+            }
+
+            let last_fut = FutWithIdx { fut: f(0), idx: 0 };
+            let last_base_timeout = last_fut.base_timeout().await;
+            let mut all_futures = vec![last_fut];
+            let mut last_error = None;
+
+            'timeout_loop: for i in 0..max {
+                let last_try = i >= max - 1;
+                let fut_timeout = future_timeout(last_base_timeout, i);
+                let until = Instant::now() + fut_timeout;
+                info!("{{{}}} Timeout-try ({:?})", i, fut_timeout);
+                loop {
+                    let timeout = sleep_until(until);
+                    pin!(timeout);
+                    match select(timeout, select_all(take(&mut all_futures))).await {
+                        Either::Left((_, futs)) => {
+                            if last_try {
+                                info!(
+                                    "{{{}}} Try timed out ({:?}), this is the last try",
+                                    i, fut_timeout
+                                );
+                                break 'timeout_loop;
+                            } else {
+                                info!(
+                                    "{{{}}} Try timed out ({:?}), spawn new async task",
+                                    i, fut_timeout
+                                );
+                                let last_fut = f(i + 1);
+                                all_futures = futs.into_inner();
+                                all_futures.push(FutWithIdx {
+                                    fut: last_fut,
+                                    idx: all_futures.len() + 1,
+                                });
+                                continue 'timeout_loop;
+                            }
+                        }
+                        Either::Right(((got_result, idx, rest_futures), _)) => match got_result {
+                            Result3::Ok(output) => {
+                                info!("{{{}/{}}} Try succeed", idx, i);
+                                punish_all_timed_out_futures(
+                                    rest_futures.into_iter().filter(|f| f.idx < idx),
+                                )
+                                .await;
+                                return TryResult::Success(output);
+                            }
+                            Result3::Err(err) => {
+                                info!("{{{}/{}}} Try error: {:?}", idx, i, err);
+                                punish_all_timed_out_futures(
+                                    rest_futures.into_iter().filter(|f| f.idx < idx),
+                                )
+                                .await;
+                                return TryResult::Error(err);
+                            }
+                            Result3::NoMoreTries(maybe_err) => {
+                                info!(
+                            "{{{}/{}}} No more tries: {:?}, will wait for the other async tasks",
+                            idx, i, maybe_err
+                        );
+                                if last_error.is_none() {
+                                    last_error = maybe_err;
+                                }
+                                all_futures = rest_futures;
+                            }
+                        },
+                    }
+                }
+            }
+
+            error!("All {} async tasks are timed out", max);
+            punish_all_timed_out_futures(take(&mut all_futures)).await;
+
+            return if let Some(err) = last_error {
+                TryResult::Error(err)
+            } else {
+                TryResult::AllTimedOut
+            };
+
+            async fn punish_all_timed_out_futures<
+                I: IntoIterator<Item = Item>,
+                Item: MaybeTimeout,
+            >(
+                iter: I,
+            ) {
+                join_all(
+                    iter.into_iter()
+                        .map(|fut| async move { fut.increase_timeout_power_if_timed_out().await }),
+                )
+                .await;
+            }
+        }
     }
 }
 
@@ -203,132 +336,6 @@ impl<T> From<TryResult<T>> for IoResult<T> {
                 "All concurrency requests are timed out",
             )),
         }
-    }
-}
-
-async fn try_with_timeout<
-    Output,
-    T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
-    F: Fn(u32) -> T,
->(
-    f: F,
-    max: u32,
-) -> TryResult<Output> {
-    struct FutWithIdx<
-        Output,
-        T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync,
-    > {
-        idx: usize,
-        fut: T,
-    }
-
-    impl<Output, T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync> Future
-        for FutWithIdx<Output, T>
-    {
-        type Output = IoResult3<Output>;
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            Pin::new(&mut self.fut).poll(cx)
-        }
-    }
-
-    #[async_trait]
-    impl<Output, T: Future<Output = IoResult3<Output>> + MaybeTimeout + Unpin + Send + Sync>
-        MaybeTimeout for FutWithIdx<Output, T>
-    {
-        async fn base_timeout(&self) -> Duration {
-            self.fut.base_timeout().await
-        }
-
-        async fn increase_timeout_power_if_timed_out(self) {
-            self.fut.increase_timeout_power_if_timed_out().await
-        }
-    }
-
-    let last_fut = FutWithIdx { fut: f(0), idx: 0 };
-    let last_base_timeout = last_fut.base_timeout().await;
-    let mut all_futures = vec![last_fut];
-    let mut last_error = None;
-
-    'timeout_loop: for i in 0..max {
-        let last_try = i >= max - 1;
-        let fut_timeout = future_timeout(last_base_timeout, i);
-        let until = Instant::now() + fut_timeout;
-        info!("{{{}}} Timeout-try ({:?})", i, fut_timeout);
-        loop {
-            let timeout = sleep_until(until);
-            pin!(timeout);
-            match select(timeout, select_all(take(&mut all_futures))).await {
-                Either::Left((_, futs)) => {
-                    if last_try {
-                        info!(
-                            "{{{}}} Try timed out ({:?}), this is the last try",
-                            i, fut_timeout
-                        );
-                        break 'timeout_loop;
-                    } else {
-                        info!(
-                            "{{{}}} Try timed out ({:?}), spawn new async task",
-                            i, fut_timeout
-                        );
-                        let last_fut = f(i + 1);
-                        all_futures = futs.into_inner();
-                        all_futures.push(FutWithIdx {
-                            fut: last_fut,
-                            idx: all_futures.len() + 1,
-                        });
-                        continue 'timeout_loop;
-                    }
-                }
-                Either::Right(((got_result, idx, rest_futures), _)) => match got_result {
-                    Result3::Ok(output) => {
-                        info!("{{{}/{}}} Try succeed", idx, i);
-                        punish_all_timed_out_futures(
-                            rest_futures.into_iter().filter(|f| f.idx < idx),
-                        )
-                        .await;
-                        return TryResult::Success(output);
-                    }
-                    Result3::Err(err) => {
-                        info!("{{{}/{}}} Try error: {:?}", idx, i, err);
-                        punish_all_timed_out_futures(
-                            rest_futures.into_iter().filter(|f| f.idx < idx),
-                        )
-                        .await;
-                        return TryResult::Error(err);
-                    }
-                    Result3::NoMoreTries(maybe_err) => {
-                        info!(
-                            "{{{}/{}}} No more tries: {:?}, will wait for the other async tasks",
-                            idx, i, maybe_err
-                        );
-                        if last_error.is_none() {
-                            last_error = maybe_err;
-                        }
-                        all_futures = rest_futures;
-                    }
-                },
-            }
-        }
-    }
-
-    error!("All {} async tasks are timed out", max);
-    punish_all_timed_out_futures(take(&mut all_futures)).await;
-
-    return if let Some(err) = last_error {
-        TryResult::Error(err)
-    } else {
-        TryResult::AllTimedOut
-    };
-
-    async fn punish_all_timed_out_futures<I: IntoIterator<Item = Item>, Item: MaybeTimeout>(
-        iter: I,
-    ) {
-        join_all(
-            iter.into_iter()
-                .map(|fut| async move { fut.increase_timeout_power_if_timed_out().await }),
-        )
-        .await;
     }
 }
 
@@ -684,10 +691,25 @@ async fn set_selected_info(selected_info: &SelectedHostInfo, host: HostInfo) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use futures::ready;
+    use super::{
+        super::{
+            cache_dir::cache_dir_path_of,
+            dot::{DotRecordKey, DotRecords, DotRecordsDashMap, DOT_FILE_NAME},
+            download::AsyncRangeReaderBuilder,
+        },
+        *,
+    };
+    use crate::{base::download::RangeReaderBuilder as BaseRangeReaderBuilder, Credential};
+    use futures::{channel::oneshot::channel, ready};
+    use hyper::Body;
+    use reqwest::header::{HeaderValue, AUTHORIZATION};
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering::Relaxed};
-    use tokio::time::{sleep, Sleep};
+    use tokio::{
+        fs::remove_file,
+        spawn,
+        time::{sleep, Sleep},
+    };
+    use warp::{path, reply::Response, Filter};
 
     struct FakedRetrier<T> {
         base_timeout: Duration,
@@ -732,19 +754,79 @@ mod tests {
         }
     }
 
+    macro_rules! starts_with_server {
+        ($io_addr:ident, $monitor_addr:ident, $io_routes:ident, $records_map:ident, $code:block) => {{
+            let (io_tx, io_rx) = channel();
+            let (monitor_tx, monitor_rx) = channel();
+            let ($io_addr, io_server) = warp::serve($io_routes).bind_with_graceful_shutdown(
+                ([127, 0, 0, 1], 0),
+                async move {
+                    io_rx.await.unwrap();
+                },
+            );
+            let $records_map = Arc::new(DotRecordsDashMap::default());
+            let monitor_routes = {
+                let records_map = $records_map.to_owned();
+                path!("v1" / "stat")
+                    .and(warp::header::value(AUTHORIZATION.as_str()))
+                    .and(warp::body::json())
+                    .map(move |authorization: HeaderValue, records: DotRecords| {
+                        assert!(authorization.to_str().unwrap().starts_with("UpToken "));
+                        records_map.merge_with_records(records);
+                        Response::new(Body::empty())
+                    })
+            };
+            let ($monitor_addr, monitor_server) = warp::serve(monitor_routes)
+                .bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async move {
+                    monitor_rx.await.unwrap();
+                });
+            spawn(io_server);
+            spawn(monitor_server);
+            sleep(Duration::from_secs(1)).await;
+            $code;
+            io_tx.send(()).unwrap();
+            monitor_tx.send(()).unwrap();
+        }};
+    }
+
     #[tokio::test]
     async fn test_try_with_timeout() -> anyhow::Result<()> {
         env_logger::try_init().ok();
+        clear_cache().await?;
 
-        let counter = Arc::new(AtomicU32::new(0));
-        let retrier_punished_1 = Arc::new(AtomicBool::new(false));
-        let retrier_punished_2 = Arc::new(AtomicBool::new(false));
-        let result = {
-            let counter = counter.to_owned();
-            let retrier_punished_1 = retrier_punished_1.to_owned();
-            let retrier_punished_2 = retrier_punished_2.to_owned();
-            try_with_timeout(
-                move |count| {
+        let io_routes = path!("file").map(|| {
+            Response::new("1234567890".into())
+        });
+
+        starts_with_server!(io_addr, monitor_addr, io_routes, records_map, {
+            let io_urls = vec![format!("http://{}", io_addr)];
+            let downloader = AsyncRangeReaderWithRangeReader::new(
+                AsyncRangeReaderBuilder::from(
+                    BaseRangeReaderBuilder::new(
+                        "bucket".to_owned(),
+                        "file".to_owned(),
+                        get_credential(),
+                        io_urls,
+                    )
+                    .use_getfile_api(false)
+                    .normalize_key(true)
+                    .monitor_urls(vec!["http://".to_owned() + &monitor_addr.to_string()])
+                    .dot_interval(Duration::from_millis(0))
+                    .max_dot_buffer_size(1),
+                )
+                .build(),
+                2,
+                0,
+            );
+
+            let counter = Arc::new(AtomicU32::new(0));
+            let retrier_punished_1 = Arc::new(AtomicBool::new(false));
+            let retrier_punished_2 = Arc::new(AtomicBool::new(false));
+            let result = {
+                let counter = counter.to_owned();
+                let retrier_punished_1 = retrier_punished_1.to_owned();
+                let retrier_punished_2 = retrier_punished_2.to_owned();
+                downloader.try_with_timeout(ApiName::IoGetfile, move |count| {
                     counter.store(count + 1, Relaxed);
                     let retrier_punished_1 = retrier_punished_1.to_owned();
                     let retrier_punished_2 = retrier_punished_2.to_owned();
@@ -763,27 +845,34 @@ mod tests {
                         ),
                         _ => unreachable!(),
                     }
-                },
-                2,
-            )
-        }
-        .await;
+                })
+            }
+            .await
+            .unwrap();
 
-        assert!(matches!(result, TryResult::Success(2)));
-        assert!(retrier_punished_1.load(Relaxed));
-        assert!(!retrier_punished_2.load(Relaxed));
-        assert_eq!(counter.load(Relaxed), 2);
+            assert_eq!(result, 2);
+            assert!(retrier_punished_1.load(Relaxed));
+            assert!(!retrier_punished_2.load(Relaxed));
+            assert_eq!(counter.load(Relaxed), 2);
 
-        counter.store(0, Relaxed);
-        retrier_punished_1.store(false, Relaxed);
-        retrier_punished_2.store(false, Relaxed);
+            sleep(Duration::from_secs(5)).await;
+            {
+                let record = records_map
+                    .get(&DotRecordKey::new(DotType::Sdk, ApiName::IoGetfile))
+                    .unwrap();
+                assert_eq!(record.success_count(), Some(1));
+                assert_eq!(record.failed_count(), Some(0));
+            }
 
-        let result = {
-            let counter = counter.to_owned();
-            let retrier_punished_1 = retrier_punished_1.to_owned();
-            let retrier_punished_2 = retrier_punished_2.to_owned();
-            try_with_timeout(
-                move |count| {
+            counter.store(0, Relaxed);
+            retrier_punished_1.store(false, Relaxed);
+            retrier_punished_2.store(false, Relaxed);
+
+            let result = {
+                let counter = counter.to_owned();
+                let retrier_punished_1 = retrier_punished_1.to_owned();
+                let retrier_punished_2 = retrier_punished_2.to_owned();
+                downloader.try_with_timeout(ApiName::IoGetfile, move |count| {
                     counter.store(count + 1, Relaxed);
                     let retrier_punished_1 = retrier_punished_1.to_owned();
                     let retrier_punished_2 = retrier_punished_2.to_owned();
@@ -802,20 +891,27 @@ mod tests {
                         ),
                         _ => unreachable!(),
                     }
-                },
-                2,
-            )
-        }
-        .await;
+                })
+            }
+            .await
+            .unwrap();
 
-        assert!(matches!(result, TryResult::Success(1)));
-        assert!(!retrier_punished_1.load(Relaxed));
-        assert!(!retrier_punished_2.load(Relaxed));
-        assert_eq!(counter.load(Relaxed), 2);
+            assert_eq!(result, 1);
+            assert!(!retrier_punished_1.load(Relaxed));
+            assert!(!retrier_punished_2.load(Relaxed));
+            assert_eq!(counter.load(Relaxed), 2);
 
-        let result = {
-            try_with_timeout(
-                move |count| {
+            sleep(Duration::from_secs(5)).await;
+            {
+                let record = records_map
+                    .get(&DotRecordKey::new(DotType::Sdk, ApiName::IoGetfile))
+                    .unwrap();
+                assert_eq!(record.success_count(), Some(2));
+                assert_eq!(record.failed_count(), Some(0));
+            }
+
+            let err = {
+                downloader.try_with_timeout(ApiName::IoGetfile, move |count| {
                     assert!(count < 2);
                     FakedRetrier::new(
                         Duration::from_millis(1000),
@@ -823,14 +919,48 @@ mod tests {
                         Duration::from_millis(4000),
                         Arc::new(AtomicBool::new(false)),
                     )
-                },
-                2,
-            )
-        }
-        .await;
+                })
+            }
+            .await
+            .unwrap_err();
 
-        assert!(matches!(result, TryResult::AllTimedOut));
+            assert_eq!(err.kind(), IoErrorKind::TimedOut);
+            assert_eq!(&err.to_string(), "All concurrency requests are timed out");
 
+            sleep(Duration::from_secs(5)).await;
+            {
+                let record = records_map
+                    .get(&DotRecordKey::new(DotType::Sdk, ApiName::IoGetfile))
+                    .unwrap();
+                assert_eq!(record.success_count(), Some(2));
+                assert_eq!(record.failed_count(), Some(1));
+            }
+        });
+
+        Ok(())
+    }
+
+    fn get_credential() -> Credential {
+        Credential::new("1234567890", "abcdefghijk")
+    }
+
+    async fn clear_cache() -> IoResult<()> {
+        let cache_file_path = cache_dir_path_of("query-cache.json").await?;
+        remove_file(&cache_file_path).await.or_else(|err| {
+            if err.kind() == IoErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })?;
+        let dot_file_path = cache_dir_path_of(DOT_FILE_NAME).await?;
+        remove_file(&dot_file_path).await.or_else(|err| {
+            if err.kind() == IoErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })?;
         Ok(())
     }
 }

--- a/src/async_api/retrier.rs
+++ b/src/async_api/retrier.rs
@@ -252,7 +252,7 @@ async fn try_with_timeout<
 
     'timeout_loop: for i in 0..max {
         let last_try = i >= max - 1;
-        let mut fut_timeout = future_timeout(last_base_timeout, i);
+        let fut_timeout = future_timeout(last_base_timeout, i);
         let until = Instant::now() + fut_timeout;
         info!("{{{}}} Timeout-try ({:?})", i, fut_timeout);
         loop {
@@ -272,7 +272,6 @@ async fn try_with_timeout<
                             i, fut_timeout
                         );
                         let last_fut = f(i + 1);
-                        fut_timeout = future_timeout(last_fut.base_timeout().await, i + 1);
                         all_futures = futs.into_inner();
                         all_futures.push(FutWithIdx {
                             fut: last_fut,

--- a/src/async_api/sync.rs
+++ b/src/async_api/sync.rs
@@ -423,7 +423,7 @@ fn block_on<F: Future>(fut: F) -> F::Output {
 
     impl ArcWake for ThreadWaker {
         fn wake_by_ref(arc_self: &Arc<Self>) {
-            debug!("({:?}) unpark", current_thread().id());
+            debug!("({:?}) unpark by ({:?})", arc_self.0.id(), current_thread().id());
             arc_self.0.unpark();
         }
     }

--- a/src/async_api/sync.rs
+++ b/src/async_api/sync.rs
@@ -423,7 +423,11 @@ fn block_on<F: Future>(fut: F) -> F::Output {
 
     impl ArcWake for ThreadWaker {
         fn wake_by_ref(arc_self: &Arc<Self>) {
-            debug!("({:?}) unpark by ({:?})", arc_self.0.id(), current_thread().id());
+            debug!(
+                "({:?}) unpark by ({:?})",
+                arc_self.0.id(),
+                current_thread().id()
+            );
             arc_self.0.unpark();
         }
     }

--- a/src/base/download.rs
+++ b/src/base/download.rs
@@ -24,7 +24,7 @@ pub(crate) struct RangeReaderBuilder {
     pub(crate) dot_tries: Option<usize>,
     pub(crate) dot_interval: Option<Duration>,
     pub(crate) max_dot_buffer_size: Option<u64>,
-    pub(crate) max_retry_concurrency: Option<usize>,
+    pub(crate) max_retry_concurrency: Option<u32>,
 }
 
 impl RangeReaderBuilder {
@@ -144,7 +144,7 @@ impl RangeReaderBuilder {
         self
     }
 
-    pub(crate) fn max_retry_concurrency(mut self, max_retry_concurrency: usize) -> Self {
+    pub(crate) fn max_retry_concurrency(mut self, max_retry_concurrency: u32) -> Self {
         self.max_retry_concurrency = Some(max_retry_concurrency);
         self
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,11 +13,7 @@ pub use multi_clusters::{
 };
 pub use single_cluster::{Config, ConfigBuilder, SingleClusterConfig, SingleClusterConfigBuilder};
 
-use super::{
-    async_api::AsyncRangeReaderBuilder,
-    base::{credential::Credential, download::RangeReaderBuilder as BaseRangeReaderBuilder},
-    sync_api::RangeReaderBuilder,
-};
+use super::base::{credential::Credential, download::RangeReaderBuilder as BaseRangeReaderBuilder};
 use log::{error, info, warn};
 use static_vars::qiniu_config;
 use std::{env, fs, sync::RwLock, time::Duration};
@@ -168,7 +164,7 @@ pub enum ClustersConfigParseError {
     TOMLError(#[from] toml::de::Error),
 }
 
-pub(super) fn build_base_range_reader_builder_from_config(
+pub(super) fn build_range_reader_builder_from_config(
     key: String,
     config: &Config,
 ) -> BaseRangeReaderBuilder {
@@ -243,14 +239,7 @@ pub(super) fn build_base_range_reader_builder_from_config(
     builder
 }
 
-pub(super) fn build_range_reader_builder_from_config(
-    key: String,
-    config: &Config,
-) -> RangeReaderBuilder {
-    build_base_range_reader_builder_from_config(key, config).into()
-}
-
-pub(super) fn build_base_range_reader_builder_from_env(
+pub(super) fn build_range_reader_builder_from_env(
     key: String,
     only_single_cluster: bool,
 ) -> Option<BaseRangeReaderBuilder> {
@@ -260,17 +249,10 @@ pub(super) fn build_base_range_reader_builder_from_env(
                 return None;
             }
             config.with_key(&key.to_owned(), move |config| {
-                build_base_range_reader_builder_from_config(key, config)
+                build_range_reader_builder_from_config(key, config)
             })
         })
     })
-}
-
-pub(super) fn build_async_range_reader_builder_from_config(
-    key: String,
-    config: &Config,
-) -> AsyncRangeReaderBuilder {
-    build_base_range_reader_builder_from_config(key, config).into()
 }
 
 #[cfg(test)]

--- a/src/config/single_cluster.rs
+++ b/src/config/single_cluster.rs
@@ -41,7 +41,7 @@ pub struct Config {
     punish_time_s: Option<u64>,
     base_timeout_ms: Option<u64>,
     dial_timeout_ms: Option<u64>,
-    max_retry_concurrency: Option<usize>,
+    max_retry_concurrency: Option<u32>,
 
     #[serde(skip)]
     extra: Extra,
@@ -289,13 +289,13 @@ impl Config {
 
     /// 获取最大并行重试次数
     #[inline]
-    pub fn max_retry_concurrency(&self) -> Option<usize> {
+    pub fn max_retry_concurrency(&self) -> Option<u32> {
         self.max_retry_concurrency
     }
 
     /// 设置最大并行重试次数，如果设置为 Some(0) 则表示禁止并行重试功能
     #[inline]
-    pub fn set_max_retry_concurrency(&mut self, max_retry_concurrency: Option<usize>) -> &mut Self {
+    pub fn set_max_retry_concurrency(&mut self, max_retry_concurrency: Option<u32>) -> &mut Self {
         self.max_retry_concurrency = max_retry_concurrency;
         self.uninit_range_reader_inner();
         self
@@ -471,7 +471,7 @@ impl ConfigBuilder {
 
     /// 配置最大并行重试次数，默认为 5，如果设置为 Some(0) 则表示禁止并行重试功能
     #[inline]
-    pub fn max_retry_concurrency(mut self, max_retry_concurrency: Option<usize>) -> Self {
+    pub fn max_retry_concurrency(mut self, max_retry_concurrency: Option<u32>) -> Self {
         self.0.max_retry_concurrency = max_retry_concurrency;
         self
     }

--- a/src/download.rs
+++ b/src/download.rs
@@ -4,7 +4,7 @@ use super::{
     },
     base::{credential::Credential, download::RangeReaderBuilder as BaseRangeReaderBuilder},
     config::{
-        build_base_range_reader_builder_from_config, build_base_range_reader_builder_from_env,
+        build_range_reader_builder_from_config, build_range_reader_builder_from_env,
         with_current_qiniu_config, Config,
     },
     sync_api::{
@@ -180,10 +180,7 @@ impl RangeReaderBuilder {
     /// * `config` - 下载配置
 
     pub fn from_config(key: impl Into<String>, config: &Config) -> Self {
-        Self(build_base_range_reader_builder_from_config(
-            key.into(),
-            config,
-        ))
+        Self(build_range_reader_builder_from_config(key.into(), config))
     }
 
     /// 从环境变量创建范围下载构建器
@@ -192,7 +189,7 @@ impl RangeReaderBuilder {
     /// * `key` - 对象名称
 
     pub fn from_env(key: impl Into<String>) -> Option<Self> {
-        build_base_range_reader_builder_from_env(key.into(), false).map(Self)
+        build_range_reader_builder_from_env(key.into(), false).map(Self)
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -142,7 +142,7 @@ impl RangeReaderBuilder {
     }
 
     /// 设置最大并行重试次数，如果设置为 0 则表示禁止并行重试功能
-    pub fn max_retry_concurrency(self, max_retry_concurrency: usize) -> Self {
+    pub fn max_retry_concurrency(self, max_retry_concurrency: u32) -> Self {
         self.with_inner(|b| b.max_retry_concurrency(max_retry_concurrency))
     }
 

--- a/src/sync_api/download.rs
+++ b/src/sync_api/download.rs
@@ -196,7 +196,7 @@ impl RangeReaderBuilder {
     }
 
     pub(crate) fn from_config(key: String, config: &Config) -> Self {
-        build_range_reader_builder_from_config(key, config)
+        build_range_reader_builder_from_config(key, config).into()
     }
 }
 


### PR DESCRIPTION
- 延长 API 调用的等待时间 https://jira.qiniu.io/browse/KODO-14343
- SDK 级别的打点逻辑移动到了外层的 retrier 模块，比放在 download 模块里更加准确
- 不会因为连接失败就打 punish 点（先前发现 punish 点数量远超预期，与最初设计思想完全不符合）
- 简单重构了下 v2.0.0 写的不太好的代码